### PR TITLE
Local port config settings

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,6 +2,8 @@
 
 local:
   db: 'local_db_name'
+  host:
+  	port: 27017
 
 remote:
   db: 'remote_db_name'
@@ -12,8 +14,8 @@ remote:
     username: 'remote_mongo_user'
     password: 'remote_mongo_pass'
 
-# For now :local only accepts DB name
-# Assumes DB is at localhost:27017
+# For now :local only accepts DB name and port
+# Assumes DB is at localhost:port
 
 # All of the parameters above are required,
 # without them, the script will fail

--- a/mongo-sync
+++ b/mongo-sync
@@ -100,6 +100,7 @@ function load_configs {
 
     # Loads:
     # - $local_db
+    # - $local_host_port
     # - $remote_db
     # - $remote_host_url
     # - $remote_host_port
@@ -140,7 +141,7 @@ function pull {
     success_msg
 
     echo "Overwriting Local DB... "
-    mongorestore -d "$local_db" "$TMPDIR"/"$remote_db" --drop > /dev/null
+    mongorestore -d "$local_db" --port "$local_host_port" "$TMPDIR"/"$remote_db" --drop > /dev/null
     success_msg
 
     cleanup
@@ -153,7 +154,7 @@ function push {
     load_configs
     
     echo "Dumping Local DB to $TMPDIR... "
-    mongodump -d "$local_db" -o "$TMPDIR" > /dev/null
+    mongodump -d "$local_db" --port "$local_host_port" -o "$TMPDIR" > /dev/null
     success_msg
 
     echo "Overwriting Remote DB with Dump... "


### PR DESCRIPTION
For Meteor mongo installations port 3001 is used, the default port in config.yml stays 27017.
