### PR TITLE
On push we should copy local_db name to remote_db name

### DIFF
--- a/mongo-sync
+++ b/mongo-sync
@@ -167,7 +167,7 @@ function push {
         -d "$remote_db" \
         -u "$remote_access_username" \
         -p "$remote_access_password" \
-        "$TMPDIR"/"$remote_db" --drop > /dev/null
+        "$TMPDIR"/"$local_db" --drop > /dev/null
     success_msg
 
     cleanup


### PR DESCRIPTION
Right now it's remote_db name to remote_db name which means we need to have the same database name on local and remote for mong-sync to work
