### PR TITLE
Fix mongo-sync issues when running from a directory with spaces

### DIFF
--- a/mongo-sync
+++ b/mongo-sync
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 set -e           # exit on error
 set -o pipefail  # trace ERR through pipes

--- a/mongo-sync
+++ b/mongo-sync
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 set -e           # exit on error
 set -o pipefail  # trace ERR through pipes
@@ -48,7 +48,7 @@ function parse_yaml {
    local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
    sed -ne "s|^\($s\):|\1|" \
         -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
-        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  "$1" |
    awk -F$fs '{
       indent = length($1)/2;
       vname[indent] = $2;
@@ -95,8 +95,8 @@ function load_configs {
     DIR=$(get_script_dir)
     local FILE="$DIR/$config"
 
-    if [ -f $FILE ]; then
-       eval $(parse_yaml $FILE)
+    if [ -f "$FILE" ]; then
+       eval $(parse_yaml "$FILE")
        success_msg
     else
        config_not_found $config


### PR DESCRIPTION
Administrative tools such as mongo-sync work well when they can run from a "syncable" directory (i.e. ~/Google Drive/). In the case of Google Drive, by default, it has a space in it. This minor update fixes directories passed into mongo-sync and to parse_yaml which fail to parse with spaces -- e.g.:

```
 ~/Google Drive/Evolute UI Development/mongo-sync/ [master*] ./mongo-sync pull
mongo-sync:
-----------
Are you sure you want to pull? Enter 'yes': yes
load_configs
Parsing 'config.yml'...
sed: /Users/kriss/Google: No such file or directory
sed: Drive/Evolute: No such file or directory
sed: UI: No such file or directory
sed: Development/mongo-sync/config.yml: No such file or directory
./mongo-sync: line 99: Error: command not found
Error on or near line 99; exiting with status 1
Cleaning up...
```
