### PR TITLE
Support for synchronization over SSH tunnel and optional auth credentials for both local/remote DB

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4,6 +4,9 @@ local:
   db: 'local_db_name'
   host:
     port: 27017
+  access:
+    username: 'local_mongo_user'
+    password: 'local_mongo_pass'
 
 remote:
   db: 'remote_db_name'
@@ -14,8 +17,14 @@ remote:
     username: 'remote_mongo_user'
     password: 'remote_mongo_pass'
 
-# For now :local only accepts DB name and port
-# Assumes DB is at localhost:port
+tunnel:
+  on: false
+  access:
+    username: 'remote_ssh_user'
+    port: 22
+
+# For now :local just
+# assumes DB is at localhost:port
 
 # All of the parameters above are required,
 # without them, the script will fail

--- a/mongo-sync
+++ b/mongo-sync
@@ -13,6 +13,7 @@ function cleanup {
         rm -rf $TMPDIR
         unset TMPDIR
     fi
+    unset REMOTE_CREDENTIALS
 }
 
 function error {
@@ -111,6 +112,11 @@ function load_configs {
     # - $remote_access_username
     # - $remote_access_password
 
+    REMOTE_CREDENTIALS=""
+    if [[ ! -z $remote_access_username ]] ; then
+        REMOTE_CREDENTIALS="-u $remote_access_username -p $remote_access_password"
+    fi
+
     TMPDIR=/tmp/"$local_db"/dump
 }
 
@@ -141,13 +147,16 @@ function pull {
     mongodump \
         -h "$remote_host_url":"$remote_host_port" \
         -d "$remote_db" \
-        -u "$remote_access_username" \
-        -p "$remote_access_password" \
+        $REMOTE_CREDENTIALS \
         -o "$TMPDIR" > /dev/null
     success_msg
 
-    echo "Overwriting Local DB... "
-    mongorestore -d "$local_db" --port "$local_host_port" "$TMPDIR"/"$remote_db" --drop > /dev/null
+    echo "Overwriting Local DB with Dump... "
+    mongorestore \
+        --port "$local_host_port" \
+        -d "$local_db" \
+        "$TMPDIR"/"$remote_db" \
+        --drop > /dev/null
     success_msg
 
     cleanup
@@ -162,15 +171,17 @@ function push {
     load_configs
 
     echo "Dumping Local DB to $TMPDIR... "
-    mongodump -d "$local_db" --port "$local_host_port" -o "$TMPDIR" > /dev/null
+    mongodump \
+        --port "$local_host_port" \
+        -d "$local_db" \
+        -o "$TMPDIR" > /dev/null
     success_msg
 
     echo "Overwriting Remote DB with Dump... "
     mongorestore \
         -h "$remote_host_url":"$remote_host_port" \
         -d "$remote_db" \
-        -u "$remote_access_username" \
-        -p "$remote_access_password" \
+        $REMOTE_CREDENTIALS \
         "$TMPDIR"/"$local_db" --drop > /dev/null
     success_msg
 

--- a/mongo-sync
+++ b/mongo-sync
@@ -13,6 +13,8 @@ function cleanup {
         rm -rf $TMPDIR
         unset TMPDIR
     fi
+    unset TUNNEL_PORT
+    unset TUNNEL_CREDENTIALS
     unset LOCAL_CREDENTIALS
     unset REMOTE_CREDENTIALS
 }
@@ -114,6 +116,10 @@ function load_configs {
     # - $remote_host_port
     # - $remote_access_username
     # - $remote_access_password
+    # - $tunnel_on
+    # - $tunnel_access_username
+    # - $tunnel_access_port
+
     LOCAL_CREDENTIALS=""
     if [[ ! -z $local_access_username ]] ; then
         LOCAL_CREDENTIALS="-u $local_access_username -p $local_access_password"
@@ -123,6 +129,9 @@ function load_configs {
     if [[ ! -z $remote_access_username ]] ; then
         REMOTE_CREDENTIALS="-u $remote_access_username -p $remote_access_password"
     fi
+
+    TUNNEL_CREDENTIALS="$tunnel_access_username@$remote_host_url"
+    TUNNEL_PORT=27018
 
     TMPDIR=/tmp/"$local_db"/dump
 }
@@ -142,6 +151,16 @@ function done_msg {
     echo
 }
 
+function open_tunnel {
+    echo "Connecting through SSH tunnel..."
+    ssh -fqTNM -S db-sync-socket -L $TUNNEL_PORT:127.0.0.1:$remote_host_port $TUNNEL_CREDENTIALS -p $tunnel_access_port
+}
+
+function close_tunnel {
+    echo "Disconnecting from SSH tunnel..."
+    ssh -S db-sync-socket -O exit $TUNNEL_CREDENTIALS 2> /dev/null
+}
+
 
 function pull {
     banner
@@ -149,6 +168,12 @@ function pull {
         get_confirmation 'pull'
     fi
     load_configs
+
+    if [ "$tunnel_on" == true ] ; then
+        open_tunnel
+        remote_host_url="localhost"
+        remote_host_port=$TUNNEL_PORT
+    fi
 
     echo "Dumping Remote DB to $TMPDIR... "
     mongodump \
@@ -167,6 +192,10 @@ function pull {
         --drop > /dev/null
     success_msg
 
+    if [ "$tunnel_on" == true ] ; then
+        close_tunnel
+    fi
+
     cleanup
     done_msg
 }
@@ -177,6 +206,12 @@ function push {
         get_confirmation 'push'
     fi
     load_configs
+
+    if [ "$tunnel_on" == true ] ; then
+        open_tunnel
+        remote_host_url="localhost"
+        remote_host_port=$TUNNEL_PORT
+    fi
 
     echo "Dumping Local DB to $TMPDIR... "
     mongodump \
@@ -193,6 +228,10 @@ function push {
         $REMOTE_CREDENTIALS \
         "$TMPDIR"/"$local_db" --drop > /dev/null
     success_msg
+
+    if [ "$tunnel_on" == true ] ; then
+        close_tunnel
+    fi
 
     cleanup
     done_msg

--- a/mongo-sync
+++ b/mongo-sync
@@ -13,6 +13,7 @@ function cleanup {
         rm -rf $TMPDIR
         unset TMPDIR
     fi
+    unset LOCAL_CREDENTIALS
     unset REMOTE_CREDENTIALS
 }
 
@@ -106,11 +107,17 @@ function load_configs {
     # Loads:
     # - $local_db
     # - $local_host_port
+    # - $local_access_username
+    # - $local_access_password
     # - $remote_db
     # - $remote_host_url
     # - $remote_host_port
     # - $remote_access_username
     # - $remote_access_password
+    LOCAL_CREDENTIALS=""
+    if [[ ! -z $local_access_username ]] ; then
+        LOCAL_CREDENTIALS="-u $local_access_username -p $local_access_password"
+    fi
 
     REMOTE_CREDENTIALS=""
     if [[ ! -z $remote_access_username ]] ; then
@@ -155,6 +162,7 @@ function pull {
     mongorestore \
         --port "$local_host_port" \
         -d "$local_db" \
+        $LOCAL_CREDENTIALS \
         "$TMPDIR"/"$remote_db" \
         --drop > /dev/null
     success_msg
@@ -174,6 +182,7 @@ function push {
     mongodump \
         --port "$local_host_port" \
         -d "$local_db" \
+        $LOCAL_CREDENTIALS \
         -o "$TMPDIR" > /dev/null
     success_msg
 


### PR DESCRIPTION
- Auth credentials for remote Mongo DB are no more strictly required: if remote_access_username is an empty string it assumes there is no need to provide login data
- Auth credentials support _(same behavior as for the remote)_ also for the local Mongo DB _(sometimes people are finicky with their choice about safety)_
- Add a bunch of options in config.yml to support SSH tunneling _(optional)_ and implemented via _"control socket"_