### PR TITLE
Add capability to use URI to allow for Atlas compatibility

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,12 +10,7 @@ local:
 
 remote:
   db: 'remote_db_name'
-  host:
-    url: 'some.remoteurl.com'
-    port: 27017
-  access:
-    username: 'remote_mongo_user'
-    password: 'remote_mongo_pass'
+  uri: 'remote_uri'
 
 tunnel:
   on: false

--- a/mongo-sync
+++ b/mongo-sync
@@ -177,9 +177,7 @@ function pull {
 
     echo "Dumping Remote DB to $TMPDIR... "
     mongodump \
-        -h "$remote_host_url":"$remote_host_port" \
-        -d "$remote_db" \
-        $REMOTE_CREDENTIALS \
+        --uri "$remote_uri" \
         -o "$TMPDIR" > /dev/null
     success_msg
 
@@ -223,9 +221,8 @@ function push {
 
     echo "Overwriting Remote DB with Dump... "
     mongorestore \
-        -h "$remote_host_url":"$remote_host_port" \
-        -d "$remote_db" \
-        $REMOTE_CREDENTIALS \
+        --uri "$remote_uri" \
+        --db "$remote_db" \
         "$TMPDIR"/"$local_db" --drop > /dev/null
     success_msg
 


### PR DESCRIPTION
This PR allows the use of URI instead of user names and passwords, which allows to interact with MongoDB Atlas sharded M0 free tier databases. Since the removal of the mLab add-on, this is the suggested Heroku workflow.

PS: Unsure of the etiquette with your repo, I realize this would require changing your local config.yml however I do hope this is useful. Thanks so much for this @sheharyar, we use this a lot.

Referenced in issue #26 